### PR TITLE
feat: Postulación: Cambiar botón "Tomar Job" por "Postularse"

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "PowerShell(Get-ChildItem -Path \"c:\\\\Users\\\\Juan Andres\\\\Documents\\\\POLI\\\\POLI 5TO SEMESTRE\\\\Frontend_Jobsi\" -Force | Select-Object Name, @{Name=\"Type\"; Expression={if\\($_.PSIsContainer\\){\"Dir\"}else{\"File\"}}})"
+    ]
+  }
+}

--- a/src/features/home/JobCard.jsx
+++ b/src/features/home/JobCard.jsx
@@ -6,7 +6,7 @@ import Button from "../../components/ui/Button.jsx";
 
 
 const JobCard = ({ job, onTomar }) => {
-    const { isDisabled, buttonText, handleTomarJob } = useJobCard(job, onTomar);
+    const { isDisabled, buttonText, handlePostularse } = useJobCard(job, onTomar);
 
     console.log("fechaPublicacion:", job.fechaPublicacion);
 
@@ -52,7 +52,7 @@ const JobCard = ({ job, onTomar }) => {
                 variant={isDisabled ? "dark": "primary"}
                 size="md"
                 fullWidth
-                onClick={handleTomarJob}
+                onClick={handlePostularse}
                 className={`mt-4 ${isDisabled ? "!cursor-not-allowed" : ""}`}
             >
                 {buttonText}

--- a/src/features/home/hooks/useJobCard.js
+++ b/src/features/home/hooks/useJobCard.js
@@ -1,21 +1,26 @@
+import { useState } from "react";
 import { useAuth } from "/src/context/AuthContext.jsx";
-import { tomarJob } from "/src/services/jobsServices/jobPublicService";
+import { postularseAJob } from "/src/services/jobsServices/jobPublicService";
 import Swal from "sweetalert2";
 
-export const useJobCard = (job, onTomar) => {
+export const useJobCard = (job, onPostulacion) => {
     const { user, token } = useAuth();
+    const [hasApplied, setHasApplied] = useState(false);
 
     const isOwner = job.solicitanteCorreo === user?.email;
-    const isAssigned = job.estado !== "PENDIENTE";
-    const isDisabled = isOwner || isAssigned;
+    const isClosed = job.estado !== "PENDIENTE";
+    const alreadyApplied = hasApplied || job.yaPostulado === true;
+    const isDisabled = isOwner || isClosed || alreadyApplied;
 
     const buttonText = isOwner
         ? "No disponible"
-        : isAssigned
-        ? "Job tomado"
-        : "Tomar Job";
+        : isClosed
+        ? "Cerrado"
+        : alreadyApplied
+        ? "Ya postulado"
+        : "Postularse";
 
-    const handleTomarJob = async () => {
+    const handlePostularse = async () => {
         if (isDisabled) return;
 
         if (!token || !user) {
@@ -27,40 +32,41 @@ export const useJobCard = (job, onTomar) => {
             return;
         }
 
+        const result = await Swal.fire({
+            title: "¿Postularse a este Job?",
+            text: "Le enviarás tu perfil al publicador para que te evalúe.",
+            icon: "question",
+            showCancelButton: true,
+            confirmButtonText: "Sí, postularme",
+            cancelButtonText: "Cancelar",
+            confirmButtonColor: "#1e3a8a",
+            cancelButtonColor: "#d33",
+        });
+
+        if (!result.isConfirmed) return;
+
         try {
-            const result = await Swal.fire({
-                title: "¿Tomar este Job?",
-                text: "Al tomarlo, te convertirás en el prestador de servicio.",
-                icon: "question",
-                showCancelButton: true,
-                confirmButtonText: "Sí, tomar",
-                cancelButtonText: "Cancelar",
-                confirmButtonColor: "#1e3a8a",
-                cancelButtonColor: "#d33",
-            });
-
-            if (!result.isConfirmed) return;
-
-            const response = await tomarJob(job.id, token);
+            const response = await postularseAJob(job.id, token);
+            setHasApplied(true);
 
             Swal.fire({
                 icon: "success",
-                title: "Job tomado 💼",
-                text: "Ahora estás postulado a este trabajo.",
-                timer: 1800,
+                title: "¡Postulación enviada!",
+                text: "El publicador revisará tu solicitud y se pondrá en contacto.",
+                timer: 2000,
                 showConfirmButton: false,
             });
 
-            if (onTomar) onTomar(response);
+            if (onPostulacion) onPostulacion(response);
 
         } catch (error) {
             Swal.fire({
                 icon: "error",
-                title: "No se pudo tomar el Job",
+                title: "No se pudo enviar la postulación",
                 text: "Intenta de nuevo más tarde.",
             });
         }
     };
 
-    return { isDisabled, buttonText, handleTomarJob };
+    return { isDisabled, buttonText, handlePostularse };
 };

--- a/src/features/home/layouts/SidebarMenu.jsx
+++ b/src/features/home/layouts/SidebarMenu.jsx
@@ -1,4 +1,4 @@
-import { FiX, FiSettings, FiHelpCircle, FiLogOut, FiBriefcase } from "react-icons/fi";
+import { FiX, FiSettings, FiHelpCircle, FiLogOut, FiBriefcase, FiBell } from "react-icons/fi";
 import { useAuth } from "../../../context/AuthContext";
 import { useModalState } from "../../../components/ui/modals/hooks/useModalState.js";
 
@@ -48,6 +48,13 @@ const SidebarMenu = ({ open, closeMenu, navigate }) => {
                         onClick={() => navigate("/mis-jobs")}
                     >
                         <FiBriefcase /> Ver mis Jobs
+                    </li>
+
+                    <li 
+                        className="flex items-center gap-3 cursor-pointer hover:text-[#1e3a8a]"
+                        onClick={() => openModal()}
+                    >
+                        <FiBell /> Notificaciones
                     </li>
 
                     <li 

--- a/src/services/jobsServices/jobPublicService.js
+++ b/src/services/jobsServices/jobPublicService.js
@@ -28,9 +28,9 @@ export const obtenerJobs = async () => {
 };
 
 
-//Tomar un job público por su ID
-export const tomarJob = async (jobId, token) => {
-    const response = await api.patch(`/v1/jobs/take-job/${jobId}`, null, {
+//Postularse a un job por su ID
+export const postularseAJob = async (jobId, token) => {
+    const response = await api.post(`/v1/postulaciones/${jobId}`, null, {
         headers: {
             Authorization: `Bearer ${token}`,
         }


### PR DESCRIPTION
**Archivos modificados:**
- jobPublicService.js → Se reemplazó `tomarJob` por `postularseAJob`, apuntando al nuevo endpoint POST /v1/postulaciones/{jobId}

- useJobCard.js → Se refactorizó completamente la lógica del hook: se agregan nuevos estados (isClosed, alreadyApplied), se incorpora estado local `hasApplied` para reflejar la postulación sin recargar, y se actualizan los textos del SweetAlert de confirmación

- JobCard.jsx → Se actualizó para consumir `handlePostularse` del hook

Nuevo comportamiento del botón:
- "Postularse"    → Job disponible para postularse
- "Ya postulado"  → El usuario ya envió su postulación (estado local o job.yaPostulado)
- "No disponible" → El usuario es el dueño del Job
- "Cerrado"       → El Job ya fue asignado (estado != PENDIENTE)

Close #43