### PR TITLE
feat: Postulación: Notificación visual de nueva postulación

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -5,6 +5,7 @@ import { MdSchool, MdBuild, MdSportsBasketball, MdWork, MdCategory } from "react
 import { PiBookOpenTextBold } from "react-icons/pi";
 
 import SidebarMenu from "/src/features/home/layouts/SidebarMenu.jsx";
+import { useNotificacionesBadge } from "/src/features/postulaciones/hooks/useNotificacionesBadge.js";
 
 const CATEGORIAS = [
     { label: "Todas",           value: "TODAS",          icon: <MdCategory /> },
@@ -20,6 +21,7 @@ const Header = ({ onFilterClick, onCategoriaChange, categoriaSeleccionada }) => 
     const navigate = useNavigate();
     const [menuOpen, setMenuOpen] = useState(false);
     const [filterOpen, setFilterOpen] = useState(false);
+    const notificacionesCount = useNotificacionesBadge();
 
     const handleFilterClick = () => {
         setFilterOpen(prev => !prev);
@@ -68,8 +70,13 @@ return (
                 <div className="flex justify-center lg:justify-end">
                     <button type="button" aria-label="Abrir menú"
                         onClick={() => setMenuOpen(true)}
-                        className="p-2 text-white rounded-full">
+                        className="relative p-2 text-white rounded-full">
                         <FiMenu className="w-8 h-8" />
+                        {notificacionesCount > 0 && (
+                            <span className="absolute -top-1 -right-1 min-w-[20px] h-5 bg-red-500 text-white text-xs font-bold rounded-full flex items-center justify-center px-1">
+                                {notificacionesCount > 99 ? "99+" : notificacionesCount}
+                            </span>
+                        )}
                     </button>
                 </div>
             </div>
@@ -103,6 +110,7 @@ return (
             open={menuOpen}
             closeMenu={() => setMenuOpen(false)}
             navigate={navigate}
+            notificacionesCount={notificacionesCount}
         />
     </div>
 )

--- a/src/features/home/layouts/SidebarMenu.jsx
+++ b/src/features/home/layouts/SidebarMenu.jsx
@@ -6,10 +6,9 @@ import Swal from "sweetalert2";
 import ComingSoonModal from "../../../components/ui/modals/ComingSoonModal";
 
 
-const SidebarMenu = ({ open, closeMenu, navigate }) => {
+const SidebarMenu = ({ open, closeMenu, navigate, notificacionesCount = 0 }) => {
 
     const { logout } = useAuth();
-
     const { isOpen, closing, opening, openModal, closeModal } = useModalState();
 
     return (
@@ -55,6 +54,11 @@ const SidebarMenu = ({ open, closeMenu, navigate }) => {
                         onClick={() => { closeMenu(); navigate("/mis-postulaciones"); }}
                     >
                         <FiBell /> Notificaciones
+                        {notificacionesCount > 0 && (
+                            <span className="ml-auto min-w-[22px] h-[22px] bg-red-500 text-white text-xs font-bold rounded-full flex items-center justify-center px-1">
+                                {notificacionesCount > 99 ? "99+" : notificacionesCount}
+                            </span>
+                        )}
                     </li>
 
                     <li 

--- a/src/features/postulaciones/hooks/useNotificacionesBadge.js
+++ b/src/features/postulaciones/hooks/useNotificacionesBadge.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "/src/context/AuthContext.jsx";
+import { obtenerPostulacionesRecibidas } from "/src/services/jobsServices/postulacionesService.js";
+
+export const useNotificacionesBadge = () => {
+    const { token } = useAuth();
+    const [count, setCount] = useState(0);
+
+    useEffect(() => {
+        if (!token) return;
+        const fetchCount = async () => {
+            try {
+                const data = await obtenerPostulacionesRecibidas(token);
+                setCount(Array.isArray(data) ? data.length : 0);
+            } catch {
+                setCount(0);
+            }
+        };
+        fetchCount();
+    }, [token]);
+
+    return count;
+};


### PR DESCRIPTION
Archivos nuevos:
- useNotificacionesBadge.js → Hook que consume el endpoint GET /v1/postulaciones/recibidas y retorna el conteo total de postulaciones pendientes del usuario autenticado

Archivos modificados:
- Header.jsx → Se integra useNotificacionesBadge y se agrega un badge rojo con el conteo sobre el botón del menú (FiMenu), siempre visible sin necesidad de abrir el sidebar. El conteo se pasa como prop notificacionesCount al SidebarMenu

- SidebarMenu.jsx → Recibe la prop notificacionesCount y muestra un badge rojo con el número al lado del ítem "Notificaciones"

Comportamiento del badge:
- Sin postulaciones  → No se muestra nada
- Entre 1 y 99       → Badge rojo con el número exacto
- 100 o más          → Badge muestra "99+"
- El conteo se refresca automáticamente en cada navegación
  ya que el Header remonta con cada cambio de ruta

Close #45

- Vista desde el header
<img width="1840" height="789" alt="image" src="https://github.com/user-attachments/assets/6595589e-21fa-41d5-bd94-5295075adf63" />


- Vista desde el sidebar
<img width="1451" height="826" alt="image" src="https://github.com/user-attachments/assets/1ccd1768-18cc-4c53-afe7-3a10e59a0bd2" />
