### PR TITLE
feat: Calificación: Botón para finalizar un Job

### DIFF
--- a/src/features/configuracion/Configuracion.jsx
+++ b/src/features/configuracion/Configuracion.jsx
@@ -71,7 +71,7 @@ const Configuracion = () => {
                     </div>
                 </div>
 
-                <div className="max-w-6xl mx-auto px-4 pb-10">
+                <div className="w-full max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 pb-10">
                     <Button variant="primary" size="sm" onClick={() => navigate("/home")}>
                         Volver
                     </Button>

--- a/src/features/jobs/VerMisJobs.jsx
+++ b/src/features/jobs/VerMisJobs.jsx
@@ -58,7 +58,16 @@ const VerMisJobs = () => {
         setActiveTab,
         handleDeleteJob,
         handleAbandonarJob,
+        handleFinalizarJob,
     } = useVerMisJobs();
+
+    const handleFinalizarConError = async (jobId) => {
+        const code = await handleFinalizarJob(jobId);
+        if (code) {
+            setErrorCode(code);
+            openModalError();
+        }
+    };
 
     const {
         isOpen: isOpenCalificar, closing: closingCalificar, opening: openingCalificar,
@@ -138,7 +147,7 @@ return (
 
                         ) : (
                             misJobs.map((job) => (
-                                <JobPublicadoCard key={job.id} job={job} onDelete={handleDeleteJob} onCalificar={abrirCalificar} />
+                                <JobPublicadoCard key={job.id} job={job} onDelete={handleDeleteJob} onCalificar={abrirCalificar} onFinalizar={handleFinalizarConError} />
                                 ))
                         )}
                     </>

--- a/src/features/jobs/hooks/useVerMisJobs.js
+++ b/src/features/jobs/hooks/useVerMisJobs.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import Swal from "sweetalert2";
-import {obtenerMisJobs, obtenerJobsTomados, deleteJob, abandonarJob} from "../../../services/jobsServices/misJobsService";
+import {obtenerMisJobs, obtenerJobsTomados, deleteJob, abandonarJob, finalizarJob} from "../../../services/jobsServices/misJobsService";
 import { useAuth } from "/src/context/AuthContext.jsx";
 
 export const useVerMisJobs = () => {
@@ -98,6 +98,17 @@ export const useVerMisJobs = () => {
         }
     };
 
+    const handleFinalizarJob = async (jobId) => {
+        try {
+            await finalizarJob(jobId, token);
+            setMisJobs(prev =>
+                prev.map(job => job.id === jobId ? { ...job, estado: "FINALIZADO" } : job)
+            );
+        } catch (error) {
+            return error.response?.status || 500;
+        }
+    };
+
     const agregarJob = (nuevoJob) => {
         setMisJobs(prev => [nuevoJob, ...prev]);
     };
@@ -111,7 +122,7 @@ export const useVerMisJobs = () => {
         activeTab,
 
         loadingPublicados,
-        loadingPostulados, 
+        loadingPostulados,
 
         // setters
         setMenuOpen,
@@ -120,6 +131,7 @@ export const useVerMisJobs = () => {
         // handlers
         handleDeleteJob,
         handleAbandonarJob,
+        handleFinalizarJob,
         agregarJob,
     };
 };

--- a/src/features/jobs/misJobs/JobPublicadoCard.jsx
+++ b/src/features/jobs/misJobs/JobPublicadoCard.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { FiEdit, FiTrash2, FiStar } from "react-icons/fi";
+import { FiEdit, FiTrash2, FiStar, FiCheckCircle } from "react-icons/fi";
 import { useModalState } from "../../../components/ui/modals/hooks/useModalState.js";
 
 import Swal from "sweetalert2";
@@ -8,10 +8,26 @@ import Button from "../../../components/ui/Button.jsx";
 import ComingSoonModal from "../../../components/ui/modals/ComingSoonModal";
 
 
-const JobPublicadoCard = ({ job, onDelete, onCalificar }) => {
+const JobPublicadoCard = ({ job, onDelete, onCalificar, onFinalizar }) => {
 
     const { isOpen, closing, opening, openModal, closeModal } = useModalState();
     const [yaCalificado, setYaCalificado] = useState(false);
+
+    const handleFinalizarClick = async () => {
+        const result = await Swal.fire({
+            title: "Finalizar Job",
+            text: "¿Estás seguro de que quieres marcar este Job como finalizado? Esta acción no se puede deshacer.",
+            icon: "warning",
+            showCancelButton: true,
+            confirmButtonColor: "#1e3a8a",
+            cancelButtonColor: "#d33",
+            confirmButtonText: "Sí, finalizar",
+            cancelButtonText: "Cancelar"
+        });
+        if (result.isConfirmed) {
+            await onFinalizar(job.id);
+        }
+    };
 
     const handleDeleteClick = async () => {
         const result = await Swal.fire({
@@ -73,6 +89,17 @@ const JobPublicadoCard = ({ job, onDelete, onCalificar }) => {
                 >
                     <FiTrash2 className="mr-2" /> Eliminar
                 </Button>
+
+                {job.estado === "EN_PROCESO" && (
+                    <Button
+                        variant="primary"
+                        size="md"
+                        className="rounded-full"
+                        onClick={handleFinalizarClick}
+                    >
+                        <FiCheckCircle className="mr-2" /> Finalizar Job
+                    </Button>
+                )}
 
                 {job.estado === "FINALIZADO" && !yaCalificado && (
                     <Button

--- a/src/services/jobsServices/misJobsService.js
+++ b/src/services/jobsServices/misJobsService.js
@@ -53,3 +53,14 @@ export const abandonarJob = async (jobId, token) => {
     return response.data;
 };
 
+//Finalizar un job publicado por el usuario
+export const finalizarJob = async (jobId, token) => {
+    const response = await api.patch(`/v1/jobs/${jobId}/finalizar`, null, {
+        headers: {
+            Authorization: `Bearer ${token}`
+        }
+    });
+
+    return response.data;
+};
+


### PR DESCRIPTION
Archivos modificados:
- misJobsService.js → agregar finalizarJob(jobId, token): PATCH /v1/jobs/{jobId}/finalizar con Bearer token

- useVerMisJobs.js → handler handleFinalizarJob que actualiza el estado del job localmente a "FINALIZADO" sin recargar la página, o retorna el código de error si el backend falla

- VerMisJobs.jsx → handleFinalizarConError conecta el handler con el ErrorBackendModal existente; pasa onFinalizar como prop a JobPublicadoCard

- JobPublicadoCard.jsx → botón "Finalizar Job" visible solo cuando job.estado === "EN_PROCESO", con SweetAlert de confirmación antes de ejecutar. Al finalizar con éxito, el estado cambia a "FINALIZADO" y el botón "Calificar" desaparece automáticamente sin recargar la página

Close #53